### PR TITLE
update peer deps for new stylelint major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/JuStTheDev/stylelint-magic-numbers#readme",
   "peerDependencies": {
-    "stylelint": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0"
+    "stylelint": ">=^9.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.3",


### PR DESCRIPTION
a new major version of `stylelint` was recently published; this PR adds support for it as a peer dep by specifying a major-version range using `>=` instead of `||`.

I "tested" this by force-installing it alongside stylelint@^14.0.0 and linted a few of my CSS files, and saw no false positives or negatives.